### PR TITLE
Updated Fief version for security fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   fief-server:
-    image: ghcr.io/fief-dev/fief:latest
+    image: ghcr.io/fief-dev/fief:0.25.3
     command: fief run-server --port 9000
     ports:
       - 9000:9000


### PR DESCRIPTION
Update for the security fix published by the Fief team.
https://github.com/fief-dev/fief/releases/tag/v0.25.3

Also, edited the Docker Compose file so that we don't always pick the latest image.